### PR TITLE
Add FlashDeconv to Single Cell section

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ Thanks this work: Hadfield, J. & Retief, J. A profusion of confusion in NGS meth
 - [splatter](https://github.com/Oshlack/splatter-paper): simulation of Single-cell RNA sequencing data.
 - [DeepNovo-DIA](https://github.com/nh2tran/DeepNovo-DIA): de novo peptide sequencing for DDA and DIA by deep learning.
 - [scVI](https://github.com/YosefLab/scVI): Deep generative modeling for single-cell transcriptomics.
+- [FlashDeconv](https://github.com/cafferychen777/flashdeconv): High-performance spatial transcriptomics deconvolution using structure-preserving randomized sketching. Achieves linear O(N) scaling and processes 1M spots in ~3 minutes, designed for Visium HD and other high-resolution platforms.
 
 ##### Protein Data Related
 


### PR DESCRIPTION
## Summary

Add FlashDeconv to the Single Cell section.

**FlashDeconv** is a high-performance spatial transcriptomics deconvolution tool:

- Uses structure-preserving randomized sketching
- **Linear O(N) scaling**: Processes 1M spots in ~3 minutes
- **Designed for high-resolution platforms**: Visium HD, Stereo-seq, etc.
- **Scanpy-style API**: Easy integration with scverse ecosystem

**Links:**
- GitHub: https://github.com/cafferychen777/flashdeconv
- Paper: https://doi.org/10.64898/2025.12.22.696108
- PyPI: https://pypi.org/project/flashdeconv/